### PR TITLE
feat(app): domain ports (IdentityVerification, Sanctions, AuditLog, Repository, Vault)

### DIFF
--- a/packages/core/src/app/ports/__contract__/audit-log-contract.ts
+++ b/packages/core/src/app/ports/__contract__/audit-log-contract.ts
@@ -1,0 +1,106 @@
+import { expect, it } from "vitest";
+import { ISODateTime } from "../../../domain/value-objects/iso-datetime.js";
+import type { AuditLogPort } from "../audit-log-port.js";
+
+/**
+ * Contract for any AuditLogPort implementation.
+ * The `corrupt` hook lets the suite assert that `verify()` detects tampering
+ * when the underlying storage is manipulated.
+ */
+export interface AuditLogContractHarness {
+  port: AuditLogPort;
+  /** Force-overwrite the `hash` of the event at `seq`, simulating corruption. */
+  corruptHashAt(seq: bigint): Promise<void>;
+}
+
+export function runAuditLogContract(factory: () => AuditLogContractHarness): void {
+  it("append() seals events with monotonic seqNumber starting at 1", async () => {
+    const { port } = factory();
+    const a = await port.append({
+      eventType: "ListRefreshed",
+      actorKey: "sys",
+      subjectKey: "ofac",
+      payload: {},
+      occurredAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+    });
+    const b = await port.append({
+      eventType: "ListRefreshed",
+      actorKey: "sys",
+      subjectKey: "un",
+      payload: {},
+      occurredAt: ISODateTime.parse("2026-04-20T12:00:01.000Z"),
+    });
+    expect(a.props.seqNumber).toBe(1n);
+    expect(b.props.seqNumber).toBe(2n);
+    expect(a.props.prevHash).not.toBe(a.props.hash);
+    expect(b.props.prevHash).toBe(a.props.hash);
+  });
+
+  it("verify() returns ok for an untampered chain", async () => {
+    const { port } = factory();
+    for (let i = 0; i < 3; i += 1) {
+      await port.append({
+        eventType: "ListRefreshed",
+        actorKey: "sys",
+        subjectKey: `src-${i}`,
+        payload: {},
+        occurredAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+      });
+    }
+    const report = await port.verify(1n, 3n);
+    expect(report.ok).toBe(true);
+    if (report.ok) expect(report.verifiedCount).toBe(3);
+  });
+
+  it("verify() detects tampering when a hash is overwritten", async () => {
+    const harness = factory();
+    for (let i = 0; i < 3; i += 1) {
+      await harness.port.append({
+        eventType: "ListRefreshed",
+        actorKey: "sys",
+        subjectKey: `src-${i}`,
+        payload: {},
+        occurredAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+      });
+    }
+    await harness.corruptHashAt(2n);
+    const report = await harness.port.verify(1n, 3n);
+    expect(report.ok).toBe(false);
+    if (!report.ok) {
+      expect(report.brokenAt).toBe(2n);
+    }
+  });
+
+  it("export() yields events within the period only", async () => {
+    const { port } = factory();
+    await port.append({
+      eventType: "ListRefreshed",
+      actorKey: "sys",
+      subjectKey: "before",
+      payload: {},
+      occurredAt: ISODateTime.parse("2026-04-20T10:00:00.000Z"),
+    });
+    await port.append({
+      eventType: "ListRefreshed",
+      actorKey: "sys",
+      subjectKey: "inside",
+      payload: {},
+      occurredAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+    });
+    await port.append({
+      eventType: "ListRefreshed",
+      actorKey: "sys",
+      subjectKey: "after",
+      payload: {},
+      occurredAt: ISODateTime.parse("2026-04-20T14:00:00.000Z"),
+    });
+    const out: string[] = [];
+    for await (const e of port.export({
+      from: ISODateTime.parse("2026-04-20T11:00:00.000Z"),
+      to: ISODateTime.parse("2026-04-20T13:00:00.000Z"),
+    })) {
+      out.push(e.props.subjectKey);
+    }
+    expect(out).toEqual(["inside"]);
+  });
+}

--- a/packages/core/src/app/ports/__contract__/identity-verification-contract.ts
+++ b/packages/core/src/app/ports/__contract__/identity-verification-contract.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "vitest";
+import { PIIString } from "../../../domain/value-objects/pii-string.js";
+import { UUID } from "../../../domain/value-objects/uuid.js";
+import type { IdentityVerificationPort } from "../identity-verification-port.js";
+
+export function runIdentityVerificationContract(factory: () => IdentityVerificationPort): void {
+  it("startVerification returns a providerSessionId + expiresAt", async () => {
+    const port = factory();
+    const out = await port.startVerification({
+      subjectId: UUID.parse("22222222-2222-4222-8222-222222222222"),
+      subjectKind: "IDENTITY",
+      fullName: PIIString.from("Ada Lovelace"),
+      kind: "KYC_DOCUMENT",
+    });
+    expect(out.providerSessionId).toBeTruthy();
+    expect(out.expiresAt).toMatch(/\dT\d/);
+  });
+
+  it("getSessionStatus throws for unknown id", async () => {
+    const port = factory();
+    await expect(
+      port.getSessionStatus(UUID.parse("33333333-3333-4333-8333-333333333333")),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("quickCheck returns UNKNOWN signal in v1 stub", async () => {
+    const port = factory();
+    const r = await port.quickCheck("test@example.com");
+    expect(r.signal).toBe("UNKNOWN");
+    expect(r.receiverId).toBe("test@example.com");
+  });
+}

--- a/packages/core/src/app/ports/__contract__/provider-credential-vault-contract.ts
+++ b/packages/core/src/app/ports/__contract__/provider-credential-vault-contract.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "vitest";
+import type { ProviderCode, ProviderCredentialVault } from "../provider-credential-vault.js";
+
+export interface VaultContractHarness {
+  vault: ProviderCredentialVault;
+  /** Store a credential set for (tenant, provider). */
+  seed(tenantId: string, provider: ProviderCode, value: Record<string, string>): void;
+  /** Count active (non-disposed) credential handles outstanding. */
+  liveHandleCount(): number;
+}
+
+export function runProviderCredentialVaultContract(factory: () => VaultContractHarness): void {
+  it("loadCredentials returns a handle that reveals the seeded value", async () => {
+    const h = factory();
+    h.seed("tenant-1", "PERSONA", { apiKey: "P-123" });
+    const disposable = await h.vault.loadCredentials("tenant-1", "PERSONA");
+    try {
+      expect(disposable.reveal().apiKey).toBe("P-123");
+    } finally {
+      disposable[Symbol.dispose]();
+    }
+  });
+
+  it("disposed handle throws on reveal()", async () => {
+    const h = factory();
+    h.seed("tenant-1", "PERSONA", { apiKey: "P-123" });
+    const disposable = await h.vault.loadCredentials("tenant-1", "PERSONA");
+    disposable[Symbol.dispose]();
+    expect(() => disposable.reveal()).toThrow();
+    expect(disposable.disposed).toBe(true);
+  });
+
+  it("credentials are not held past request scope (using-style)", async () => {
+    const h = factory();
+    h.seed("tenant-1", "PERSONA", { apiKey: "P-123" });
+    async function scoped(): Promise<void> {
+      const d = await h.vault.loadCredentials("tenant-1", "PERSONA");
+      d.reveal();
+      d[Symbol.dispose]();
+    }
+    await scoped();
+    // After the scope, no live handles remain.
+    expect(h.liveHandleCount()).toBe(0);
+  });
+
+  it("rotate() causes subsequent loadCredentials to see new value", async () => {
+    const h = factory();
+    h.seed("tenant-1", "PERSONA", { apiKey: "V1" });
+    const d1 = await h.vault.loadCredentials("tenant-1", "PERSONA");
+    expect(d1.reveal().apiKey).toBe("V1");
+    d1[Symbol.dispose]();
+
+    h.seed("tenant-1", "PERSONA", { apiKey: "V2" });
+    await h.vault.rotate("tenant-1", "PERSONA");
+
+    const d2 = await h.vault.loadCredentials("tenant-1", "PERSONA");
+    expect(d2.reveal().apiKey).toBe("V2");
+    d2[Symbol.dispose]();
+  });
+}

--- a/packages/core/src/app/ports/__contract__/sanctions-screening-contract.ts
+++ b/packages/core/src/app/ports/__contract__/sanctions-screening-contract.ts
@@ -1,0 +1,30 @@
+import { expect, it } from "vitest";
+import { PIIString } from "../../../domain/value-objects/pii-string.js";
+import { UUID } from "../../../domain/value-objects/uuid.js";
+import type { SanctionsScreeningPort } from "../sanctions-screening-port.js";
+
+export function runSanctionsScreeningContract(factory: () => SanctionsScreeningPort): void {
+  it("screen() returns an array of matches (possibly empty)", async () => {
+    const port = factory();
+    const matches = await port.screen({
+      kind: "IDENTITY",
+      id: UUID.parse("44444444-4444-4444-8444-444444444444"),
+      fullName: PIIString.from("Test Person"),
+      country: "CR",
+    });
+    expect(Array.isArray(matches)).toBe(true);
+  });
+
+  it("getMatch() returns null for unknown id", async () => {
+    const port = factory();
+    const got = await port.getMatch(UUID.parse("55555555-5555-4555-8555-555555555555"));
+    expect(got).toBeNull();
+  });
+
+  it("refreshLists() reports counts for the requested source", async () => {
+    const port = factory();
+    const report = await port.refreshLists("OFAC_SDN");
+    expect(report.source).toBe("OFAC_SDN");
+    expect(typeof report.entriesAdded).toBe("number");
+  });
+}

--- a/packages/core/src/app/ports/__contract__/verification-repository-contract.ts
+++ b/packages/core/src/app/ports/__contract__/verification-repository-contract.ts
@@ -1,0 +1,92 @@
+import { expect, it } from "vitest";
+import { Identity } from "../../../domain/entities/identity.js";
+import { SanctionsMatch } from "../../../domain/entities/sanctions-match.js";
+import { VerificationSession } from "../../../domain/entities/verification-session.js";
+import { ISODateTime } from "../../../domain/value-objects/iso-datetime.js";
+import { PIIString } from "../../../domain/value-objects/pii-string.js";
+import { UUID } from "../../../domain/value-objects/uuid.js";
+import type { VerificationRepositoryPort } from "../verification-repository-port.js";
+
+export function runVerificationRepositoryContract(factory: () => VerificationRepositoryPort): void {
+  const iso = ISODateTime.parse("2026-04-20T12:00:00.000Z");
+
+  it("saveIdentity + getIdentity round-trip", async () => {
+    const repo = factory();
+    const id = UUID.parse("66666666-6666-4666-8666-666666666666");
+    const identity = Identity.create({
+      id,
+      fullName: PIIString.from("Ada Lovelace"),
+      country: "CR",
+      createdAt: iso,
+    });
+    await repo.saveIdentity(identity);
+    const loaded = await repo.getIdentity(id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.props.country).toBe("CR");
+  });
+
+  it("getIdentity returns null for unknown id", async () => {
+    const repo = factory();
+    const missing = await repo.getIdentity(UUID.parse("77777777-7777-4777-8777-777777777777"));
+    expect(missing).toBeNull();
+  });
+
+  it("saveSession is idempotent for same id (upsert semantics)", async () => {
+    const repo = factory();
+    const sid = UUID.parse("88888888-8888-4888-8888-888888888888");
+    const iid = UUID.parse("99999999-9999-4999-8999-999999999999");
+    const s = VerificationSession.create({
+      id: sid,
+      identityId: iid,
+      provider: "PERSONA",
+      jurisdiction: "CR",
+      startedAt: iso,
+    });
+    await repo.saveSession(s);
+    await repo.saveSession(s);
+    const reloaded = await repo.getSession(sid);
+    expect(reloaded?.id).toBe(sid);
+  });
+
+  it("getSessionByProviderRef locates session by provider ref", async () => {
+    const repo = factory();
+    const s = VerificationSession.create({
+      id: UUID.parse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+      identityId: UUID.parse("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      provider: "PERSONA",
+      jurisdiction: "CR",
+      startedAt: iso,
+      providerRef: "persona-inq-xyz",
+    });
+    await repo.saveSession(s);
+    const found = await repo.getSessionByProviderRef("persona-inq-xyz");
+    expect(found?.id).toBe(s.id);
+  });
+
+  it("listMatchesBySubject filters by status", async () => {
+    const repo = factory();
+    const subject = UUID.parse("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+    const m1 = SanctionsMatch.create({
+      id: UUID.parse("dddddddd-dddd-4ddd-8ddd-dddddddddd01"),
+      identityId: subject,
+      list: "OFAC_SDN",
+      listEntryId: "E1",
+      confidence: 90,
+      matchedName: "X",
+      detectedAt: iso,
+    });
+    const m2 = SanctionsMatch.create({
+      id: UUID.parse("dddddddd-dddd-4ddd-8ddd-dddddddddd02"),
+      identityId: subject,
+      list: "UN",
+      listEntryId: "E2",
+      confidence: 85,
+      matchedName: "Y",
+      detectedAt: iso,
+    });
+    await repo.saveMatch(m1);
+    await repo.saveMatch(m2);
+    const pending = await repo.listMatchesBySubject({ subjectId: subject, status: "PENDING" });
+    expect(pending).toHaveLength(2);
+  });
+}

--- a/packages/core/src/app/ports/__fakes__/fake-audit-log.ts
+++ b/packages/core/src/app/ports/__fakes__/fake-audit-log.ts
@@ -1,0 +1,112 @@
+import { ComplianceEvent } from "../../../domain/entities/compliance-event.js";
+import { AuditChainService } from "../../../domain/services/audit-chain-service.js";
+import { Hex32 } from "../../../domain/value-objects/hex32.js";
+import type { ISODateTime } from "../../../domain/value-objects/iso-datetime.js";
+import type { AppendInput, AuditLogPort, IntegrityReport, Period } from "../audit-log-port.js";
+
+/**
+ * In-memory AuditLogPort. Exposes `corruptHashAt` so the contract suite can
+ * assert tamper detection.
+ */
+export class FakeAuditLog implements AuditLogPort {
+  private readonly events: Array<{
+    seqNumber: bigint;
+    prevHash: string;
+    hash: string;
+    eventType: string;
+    actorKey: string;
+    subjectKey: string;
+    payload: Record<string, unknown>;
+    occurredAt: ISODateTime;
+  }> = [];
+  private readonly chain = new AuditChainService();
+
+  async append(input: AppendInput): Promise<ComplianceEvent> {
+    const last = this.events.at(-1);
+    const sealed = this.chain.append(
+      input,
+      last ? { seqNumber: last.seqNumber, hash: Hex32.parse(last.hash) } : null,
+    );
+    this.events.push({
+      seqNumber: sealed.seqNumber,
+      prevHash: sealed.prevHash,
+      hash: sealed.hash,
+      eventType: sealed.eventType,
+      actorKey: sealed.actorKey,
+      subjectKey: sealed.subjectKey,
+      payload: { ...sealed.payload },
+      occurredAt: sealed.occurredAt,
+    });
+    return ComplianceEvent.ofSealed({
+      seqNumber: sealed.seqNumber,
+      prevHash: sealed.prevHash,
+      hash: sealed.hash,
+      eventType: sealed.eventType,
+      actorKey: sealed.actorKey,
+      subjectKey: sealed.subjectKey,
+      payload: { ...sealed.payload },
+      occurredAt: sealed.occurredAt,
+    });
+  }
+
+  async verify(fromSeq: bigint, toSeq: bigint): Promise<IntegrityReport> {
+    const slice = this.events
+      .filter((e) => e.seqNumber >= fromSeq && e.seqNumber <= toSeq)
+      .map((e) => ({
+        seqNumber: e.seqNumber,
+        prevHash: Hex32.parse(e.prevHash),
+        hash: Hex32.parse(e.hash),
+        eventType: e.eventType,
+        actorKey: e.actorKey,
+        subjectKey: e.subjectKey,
+        payload: e.payload,
+        occurredAt: e.occurredAt,
+      }));
+    const result = this.chain.verify(slice);
+    if (result.ok) return { ok: true, verifiedCount: result.count };
+    return { ok: false, brokenAt: result.brokenAt, reason: result.reason };
+  }
+
+  async *export(period: Period): AsyncIterable<ComplianceEvent> {
+    for (const e of this.events) {
+      if (e.occurredAt >= period.from && e.occurredAt <= period.to) {
+        yield ComplianceEvent.ofSealed({
+          seqNumber: e.seqNumber,
+          prevHash: Hex32.parse(e.prevHash),
+          hash: Hex32.parse(e.hash),
+          eventType: e.eventType,
+          actorKey: e.actorKey,
+          subjectKey: e.subjectKey,
+          payload: e.payload,
+          occurredAt: e.occurredAt,
+        });
+      }
+    }
+  }
+
+  async *stream(fromSeq: bigint): AsyncIterable<ComplianceEvent> {
+    for (const e of this.events) {
+      if (e.seqNumber < fromSeq) continue;
+      yield ComplianceEvent.ofSealed({
+        seqNumber: e.seqNumber,
+        prevHash: Hex32.parse(e.prevHash),
+        hash: Hex32.parse(e.hash),
+        eventType: e.eventType,
+        actorKey: e.actorKey,
+        subjectKey: e.subjectKey,
+        payload: e.payload,
+        occurredAt: e.occurredAt,
+      });
+    }
+  }
+
+  /** Test hook: simulate storage tampering. */
+  async corruptHashAt(seq: bigint): Promise<void> {
+    const target = this.events.find((e) => e.seqNumber === seq);
+    if (!target) throw new Error(`no event at seq=${seq}`);
+    // Flip one hex char (deterministic) so chain verification fails.
+    const first = target.hash[0] ?? "0";
+    const replacement = first === "0" ? "1" : "0";
+    target.hash = `${replacement}${target.hash.slice(1)}`;
+  }
+}

--- a/packages/core/src/app/ports/__fakes__/fake-identity-verification.ts
+++ b/packages/core/src/app/ports/__fakes__/fake-identity-verification.ts
@@ -1,0 +1,60 @@
+import type { VerificationSession } from "../../../domain/entities/verification-session.js";
+import { ISODateTime } from "../../../domain/value-objects/iso-datetime.js";
+import type { UUID } from "../../../domain/value-objects/uuid.js";
+import type {
+  EvidenceBundle,
+  IdentityVerificationPort,
+  QuickCheckResult,
+  StartVerificationInput,
+  StartVerificationOutput,
+} from "../identity-verification-port.js";
+
+/**
+ * Deterministic fake for tests. `startVerification` always succeeds with a
+ * canned providerSessionId; `getSessionStatus` serves the session registered
+ * via `registerSession`.
+ */
+export class FakeIdentityVerification implements IdentityVerificationPort {
+  readonly startCalls: StartVerificationInput[] = [];
+  private readonly sessions = new Map<string, VerificationSession>();
+  private readonly evidence = new Map<string, EvidenceBundle>();
+  private counter = 0;
+
+  registerSession(session: VerificationSession): void {
+    this.sessions.set(session.id, session);
+  }
+
+  registerEvidence(bundle: EvidenceBundle): void {
+    this.evidence.set(bundle.sessionId, bundle);
+  }
+
+  async startVerification(input: StartVerificationInput): Promise<StartVerificationOutput> {
+    this.startCalls.push(input);
+    this.counter += 1;
+    return {
+      providerSessionId: `fake-inq-${this.counter}`,
+      hostedFlowUrl: `https://fake.example/flow/${this.counter}`,
+      expiresAt: ISODateTime.parse("2026-04-21T12:00:00.000Z"),
+    };
+  }
+
+  async getSessionStatus(sessionId: UUID): Promise<VerificationSession> {
+    const s = this.sessions.get(sessionId);
+    if (!s) throw new Error(`unknown session: ${sessionId}`);
+    return s;
+  }
+
+  async fetchEvidence(sessionId: UUID): Promise<EvidenceBundle> {
+    const e = this.evidence.get(sessionId);
+    if (!e) throw new Error(`no evidence for session: ${sessionId}`);
+    return e;
+  }
+
+  async quickCheck(receiverId: string): Promise<QuickCheckResult> {
+    return {
+      receiverId,
+      signal: "UNKNOWN",
+      checkedAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+    };
+  }
+}

--- a/packages/core/src/app/ports/__fakes__/fake-provider-credential-vault.ts
+++ b/packages/core/src/app/ports/__fakes__/fake-provider-credential-vault.ts
@@ -1,0 +1,37 @@
+import {
+  type DisposableCredentials,
+  type ProviderCode,
+  type ProviderCredentialVault,
+  type ProviderCredentialsValue,
+  makeDisposableCredentials,
+} from "../provider-credential-vault.js";
+
+export class FakeProviderCredentialVault implements ProviderCredentialVault {
+  private readonly store = new Map<string, ProviderCredentialsValue>();
+  private readonly outstanding = new Set<DisposableCredentials>();
+
+  seed(tenantId: string, provider: ProviderCode, value: Record<string, string>): void {
+    this.store.set(`${tenantId}|${provider}`, { ...value });
+  }
+
+  liveHandleCount(): number {
+    let live = 0;
+    for (const d of this.outstanding) {
+      if (!d.disposed) live += 1;
+    }
+    return live;
+  }
+
+  async loadCredentials(tenantId: string, provider: ProviderCode): Promise<DisposableCredentials> {
+    const value = this.store.get(`${tenantId}|${provider}`);
+    if (!value) throw new Error(`no credentials for ${tenantId}/${provider}`);
+    const handle = makeDisposableCredentials(value);
+    this.outstanding.add(handle);
+    return handle;
+  }
+
+  async rotate(_tenantId: string, _provider: ProviderCode): Promise<void> {
+    // Rotation is a storage-side operation; the fake just relies on `seed`
+    // being called with the new value before rotate.
+  }
+}

--- a/packages/core/src/app/ports/__fakes__/fake-sanctions-screening.ts
+++ b/packages/core/src/app/ports/__fakes__/fake-sanctions-screening.ts
@@ -1,0 +1,54 @@
+import type { SanctionsList, SanctionsMatch } from "../../../domain/entities/sanctions-match.js";
+import { ISODateTime } from "../../../domain/value-objects/iso-datetime.js";
+import type { UUID } from "../../../domain/value-objects/uuid.js";
+import type {
+  MatchResolution,
+  RefreshReport,
+  SanctionsScreeningPort,
+  ScreeningSubject,
+} from "../sanctions-screening-port.js";
+
+export class FakeSanctionsScreening implements SanctionsScreeningPort {
+  readonly screenCalls: ScreeningSubject[] = [];
+  private readonly matches = new Map<string, SanctionsMatch>();
+  private nextMatches: readonly SanctionsMatch[] = [];
+
+  /** Seed: the next call to screen() returns these matches. */
+  queueMatches(ms: readonly SanctionsMatch[]): void {
+    this.nextMatches = ms;
+    for (const m of ms) this.matches.set(m.props.id, m);
+  }
+
+  async screen(subject: ScreeningSubject): Promise<readonly SanctionsMatch[]> {
+    this.screenCalls.push(subject);
+    const out = this.nextMatches;
+    this.nextMatches = [];
+    return out;
+  }
+
+  async refreshLists(source: SanctionsList): Promise<RefreshReport> {
+    return {
+      source,
+      fetchedAt: ISODateTime.parse("2026-04-20T12:00:00.000Z"),
+      entriesAdded: 0,
+      entriesRemoved: 0,
+      entriesUpdated: 0,
+    };
+  }
+
+  async getMatch(id: UUID): Promise<SanctionsMatch | null> {
+    return this.matches.get(id) ?? null;
+  }
+
+  async resolveMatch(id: UUID, resolution: MatchResolution): Promise<SanctionsMatch> {
+    const existing = this.matches.get(id);
+    if (!existing) throw new Error(`unknown match: ${id}`);
+    const at = ISODateTime.parse("2026-04-20T12:00:00.000Z");
+    const resolved =
+      resolution.kind === "CONFIRMED_MATCH"
+        ? existing.confirm(resolution.reviewer, at, resolution.notes)
+        : existing.markFalsePositive(resolution.reviewer, at, resolution.notes);
+    this.matches.set(id, resolved);
+    return resolved;
+  }
+}

--- a/packages/core/src/app/ports/__fakes__/fake-verification-repository.ts
+++ b/packages/core/src/app/ports/__fakes__/fake-verification-repository.ts
@@ -1,0 +1,61 @@
+import type { Identity } from "../../../domain/entities/identity.js";
+import type { SanctionsMatch } from "../../../domain/entities/sanctions-match.js";
+import type { VerificationSession } from "../../../domain/entities/verification-session.js";
+import type { UUID } from "../../../domain/value-objects/uuid.js";
+import type {
+  ListMatchesFilter,
+  ListSessionsFilter,
+  VerificationRepositoryPort,
+} from "../verification-repository-port.js";
+
+export class FakeVerificationRepository implements VerificationRepositoryPort {
+  private readonly identities = new Map<string, Identity>();
+  private readonly sessions = new Map<string, VerificationSession>();
+  private readonly matches = new Map<string, SanctionsMatch>();
+
+  async saveIdentity(identity: Identity): Promise<void> {
+    this.identities.set(identity.props.id, identity);
+  }
+
+  async getIdentity(id: UUID): Promise<Identity | null> {
+    return this.identities.get(id) ?? null;
+  }
+
+  async saveSession(session: VerificationSession): Promise<void> {
+    this.sessions.set(session.id, session);
+  }
+
+  async getSession(id: UUID): Promise<VerificationSession | null> {
+    return this.sessions.get(id) ?? null;
+  }
+
+  async getSessionByProviderRef(providerRef: string): Promise<VerificationSession | null> {
+    for (const s of this.sessions.values()) {
+      if (s.props.providerRef === providerRef) return s;
+    }
+    return null;
+  }
+
+  async listSessionsBySubject(filter: ListSessionsFilter): Promise<readonly VerificationSession[]> {
+    const all = [...this.sessions.values()].filter((s) => s.props.identityId === filter.subjectId);
+    const filtered = all.filter((s) => {
+      if (filter.status && s.status !== filter.status) return false;
+      if (filter.from && s.props.startedAt < filter.from) return false;
+      if (filter.to && s.props.startedAt > filter.to) return false;
+      return true;
+    });
+    return filter.limit ? filtered.slice(0, filter.limit) : filtered;
+  }
+
+  async saveMatch(match: SanctionsMatch): Promise<void> {
+    this.matches.set(match.props.id, match);
+  }
+
+  async listMatchesBySubject(filter: ListMatchesFilter): Promise<readonly SanctionsMatch[]> {
+    const all = [...this.matches.values()].filter((m) => m.props.identityId === filter.subjectId);
+    const filtered = filter.status
+      ? all.filter((m) => m.props.reviewStatus === filter.status)
+      : all;
+    return filter.limit ? filtered.slice(0, filter.limit) : filtered;
+  }
+}

--- a/packages/core/src/app/ports/audit-log-port.ts
+++ b/packages/core/src/app/ports/audit-log-port.ts
@@ -1,0 +1,45 @@
+import type { ComplianceEvent } from "../../domain/entities/compliance-event.js";
+import type { ISODateTime } from "../../domain/value-objects/iso-datetime.js";
+
+/**
+ * AuditLogPort — append-only compliance log with SHA-256 hash chain.
+ *
+ * Contract:
+ *  - `append()` persists a new event. `seqNumber`, `prevHash`, `hash` are
+ *    assigned by the adapter (via AuditChainService). Returns the sealed
+ *    ComplianceEvent.
+ *  - `verify(fromSeq, toSeq)` recomputes the chain and returns an
+ *    IntegrityReport. Used by daily cron + pre-export.
+ *  - `export(period)` streams events within a time range (legal export).
+ *  - `stream(fromSeq)` streams all events from a sequence number (follower
+ *    replication / warm-standby).
+ */
+
+export type IntegrityReport =
+  | { readonly ok: true; readonly verifiedCount: number }
+  | {
+      readonly ok: false;
+      readonly brokenAt: bigint;
+      readonly reason: "hash-mismatch" | "seq-gap" | "prev-hash-mismatch";
+    };
+
+export interface Period {
+  readonly from: ISODateTime;
+  readonly to: ISODateTime;
+}
+
+/** Input shape for `append` — chain fields are computed by the adapter. */
+export type AppendInput = {
+  readonly eventType: string;
+  readonly actorKey: string;
+  readonly subjectKey: string;
+  readonly payload: Record<string, unknown>;
+  readonly occurredAt: ISODateTime;
+};
+
+export interface AuditLogPort {
+  append(input: AppendInput): Promise<ComplianceEvent>;
+  verify(fromSeq: bigint, toSeq: bigint): Promise<IntegrityReport>;
+  export(period: Period): AsyncIterable<ComplianceEvent>;
+  stream(fromSeq: bigint): AsyncIterable<ComplianceEvent>;
+}

--- a/packages/core/src/app/ports/domain-ports.test.ts
+++ b/packages/core/src/app/ports/domain-ports.test.ts
@@ -1,0 +1,41 @@
+import { describe } from "vitest";
+import { runAuditLogContract } from "./__contract__/audit-log-contract.js";
+import { runIdentityVerificationContract } from "./__contract__/identity-verification-contract.js";
+import { runProviderCredentialVaultContract } from "./__contract__/provider-credential-vault-contract.js";
+import { runSanctionsScreeningContract } from "./__contract__/sanctions-screening-contract.js";
+import { runVerificationRepositoryContract } from "./__contract__/verification-repository-contract.js";
+import { FakeAuditLog } from "./__fakes__/fake-audit-log.js";
+import { FakeIdentityVerification } from "./__fakes__/fake-identity-verification.js";
+import { FakeProviderCredentialVault } from "./__fakes__/fake-provider-credential-vault.js";
+import { FakeSanctionsScreening } from "./__fakes__/fake-sanctions-screening.js";
+import { FakeVerificationRepository } from "./__fakes__/fake-verification-repository.js";
+
+describe("IdentityVerificationPort — FakeIdentityVerification contract", () => {
+  runIdentityVerificationContract(() => new FakeIdentityVerification());
+});
+
+describe("SanctionsScreeningPort — FakeSanctionsScreening contract", () => {
+  runSanctionsScreeningContract(() => new FakeSanctionsScreening());
+});
+
+describe("AuditLogPort — FakeAuditLog contract", () => {
+  runAuditLogContract(() => {
+    const port = new FakeAuditLog();
+    return { port, corruptHashAt: (seq) => port.corruptHashAt(seq) };
+  });
+});
+
+describe("VerificationRepositoryPort — FakeVerificationRepository contract", () => {
+  runVerificationRepositoryContract(() => new FakeVerificationRepository());
+});
+
+describe("ProviderCredentialVault — FakeProviderCredentialVault contract", () => {
+  runProviderCredentialVaultContract(() => {
+    const vault = new FakeProviderCredentialVault();
+    return {
+      vault,
+      seed: (t, p, v) => vault.seed(t, p, v),
+      liveHandleCount: () => vault.liveHandleCount(),
+    };
+  });
+});

--- a/packages/core/src/app/ports/identity-verification-port.ts
+++ b/packages/core/src/app/ports/identity-verification-port.ts
@@ -1,0 +1,65 @@
+import type { VerificationSession } from "../../domain/entities/verification-session.js";
+import type { PIIString } from "../../domain/value-objects/pii-string.js";
+import type { UUID } from "../../domain/value-objects/uuid.js";
+
+/**
+ * IdentityVerificationPort — outbound abstraction over KYC providers
+ * (Persona, Ondato, Incode, …).
+ *
+ * All PII-bearing inputs MUST use `PIIString` wrapper; adapters handle the
+ * `unsafeReveal()` boundary crossing.
+ */
+
+export type VerificationKind =
+  | "KYC_DOCUMENT"
+  | "KYC_LIVENESS"
+  | "KYC_FACE_MATCH"
+  | "KYB_REGISTRATION"
+  | "KYB_UBO"
+  | "AGE"
+  | "PROOF_OF_ADDRESS"
+  | "PROOF_OF_PERSONHOOD";
+
+export type SubjectKind = "IDENTITY" | "BUSINESS";
+
+export interface StartVerificationInput {
+  readonly subjectId: UUID;
+  readonly subjectKind: SubjectKind;
+  readonly fullName: PIIString;
+  readonly kind: VerificationKind;
+  readonly templateId?: string;
+  readonly returnUrl?: string;
+}
+
+export interface StartVerificationOutput {
+  readonly providerSessionId: string;
+  readonly hostedFlowUrl: string | undefined;
+  readonly expiresAt: string;
+}
+
+/** Opaque blob reference; actual bytes live in the evidence store. */
+export interface EvidenceBundle {
+  readonly sessionId: UUID;
+  readonly documents: ReadonlyArray<{ kind: string; storageRef: string; sha256: string }>;
+  readonly selfie?: { storageRef: string; sha256: string };
+  readonly livenessScore?: number;
+  readonly faceMatchScore?: number;
+}
+
+/**
+ * `quickCheck(receiverId)` — stubbed out in v1 (see spec §7.1). Returns a
+ * deterministic shape so callers can wire the UX without the backend.
+ */
+export interface QuickCheckResult {
+  readonly receiverId: string;
+  readonly signal: "UNKNOWN" | "LIKELY_REAL" | "LIKELY_FAKE";
+  readonly checkedAt: string;
+}
+
+export interface IdentityVerificationPort {
+  startVerification(input: StartVerificationInput): Promise<StartVerificationOutput>;
+  getSessionStatus(sessionId: UUID): Promise<VerificationSession>;
+  fetchEvidence(sessionId: UUID): Promise<EvidenceBundle>;
+  /** v1 stub — returns `UNKNOWN` until a provider is wired. */
+  quickCheck(receiverId: string): Promise<QuickCheckResult>;
+}

--- a/packages/core/src/app/ports/index.ts
+++ b/packages/core/src/app/ports/index.ts
@@ -1,6 +1,7 @@
-// Public re-exports for the application port layer (infrastructure ports).
-// Domain ports are added in Task 18.
+// Public re-exports for the application port layer.
+// Infrastructure ports (Task 17) + domain ports (Task 18).
 
+// Infrastructure
 export type { ClockPort } from "./clock-port.js";
 export type { LoggerPort } from "./logger-port.js";
 export type {
@@ -13,3 +14,38 @@ export type { TracingPort, TracingSpan } from "./tracing-port.js";
 export type { EventBusPort, EventHandler, Unsubscribe } from "./event-bus-port.js";
 export type { IdempotencyPort } from "./idempotency-port.js";
 export type { SecretsStorePort } from "./secrets-store-port.js";
+
+// Domain
+export type {
+  EvidenceBundle,
+  IdentityVerificationPort,
+  QuickCheckResult,
+  StartVerificationInput,
+  StartVerificationOutput,
+  SubjectKind,
+  VerificationKind,
+} from "./identity-verification-port.js";
+export type {
+  MatchResolution,
+  RefreshReport,
+  SanctionsScreeningPort,
+  ScreeningSubject,
+} from "./sanctions-screening-port.js";
+export type {
+  AppendInput,
+  AuditLogPort,
+  IntegrityReport,
+  Period,
+} from "./audit-log-port.js";
+export type {
+  ListMatchesFilter,
+  ListSessionsFilter,
+  VerificationRepositoryPort,
+} from "./verification-repository-port.js";
+export {
+  makeDisposableCredentials,
+  type DisposableCredentials,
+  type ProviderCode,
+  type ProviderCredentialVault,
+  type ProviderCredentialsValue,
+} from "./provider-credential-vault.js";

--- a/packages/core/src/app/ports/provider-credential-vault.ts
+++ b/packages/core/src/app/ports/provider-credential-vault.ts
@@ -1,0 +1,67 @@
+/**
+ * ProviderCredentialVault — abstraction for API keys / OAuth tokens for
+ * KYC/AML providers. Implementations: Vault, AWS KMS, GCP KMS, sealed-secrets.
+ *
+ * SECURITY:
+ *  - Credentials are returned wrapped in a `DisposableCredentials` handle so
+ *    callers can zero the buffer at the end of the request scope.
+ *  - Holding credentials past request scope is a security violation; the
+ *    Disposable pattern + `[Symbol.dispose]` gives the runtime a chance to
+ *    clear memory (using `using` declarations, TS 5.2+).
+ *  - `rotate()` is called by the ops cron; new calls to `loadCredentials()`
+ *    after rotation MUST return the new value.
+ */
+
+export type ProviderCode = "PERSONA" | "ONDATO" | "INCODE" | "SNAP" | "WORLD_ID";
+
+export interface ProviderCredentialsValue {
+  readonly apiKey?: string;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly bearer?: string;
+  readonly mtlsCertPem?: string;
+  readonly mtlsKeyPem?: string;
+}
+
+/**
+ * Disposable wrapper. Tests assert credentials are not held past scope by
+ * introspecting the `disposed` flag.
+ */
+export interface DisposableCredentials extends Disposable {
+  readonly disposed: boolean;
+  reveal(): ProviderCredentialsValue;
+}
+
+export interface ProviderCredentialVault {
+  loadCredentials(tenantId: string, provider: ProviderCode): Promise<DisposableCredentials>;
+  rotate(tenantId: string, provider: ProviderCode): Promise<void>;
+}
+
+/**
+ * Helper: build a DisposableCredentials that zeros (best-effort) its backing
+ * record on dispose. Adapters can use this directly; tests can inspect it.
+ */
+export function makeDisposableCredentials(value: ProviderCredentialsValue): DisposableCredentials {
+  let data: Record<string, string | undefined> | null = { ...value };
+  let isDisposed = false;
+
+  return {
+    get disposed(): boolean {
+      return isDisposed;
+    },
+    reveal(): ProviderCredentialsValue {
+      if (isDisposed || data === null) {
+        throw new Error("DisposableCredentials has been disposed");
+      }
+      return { ...data };
+    },
+    [Symbol.dispose](): void {
+      if (isDisposed) return;
+      isDisposed = true;
+      if (data !== null) {
+        for (const k of Object.keys(data)) data[k] = undefined;
+        data = null;
+      }
+    },
+  };
+}

--- a/packages/core/src/app/ports/sanctions-screening-port.ts
+++ b/packages/core/src/app/ports/sanctions-screening-port.ts
@@ -1,0 +1,56 @@
+import type { SanctionsList, SanctionsMatch } from "../../domain/entities/sanctions-match.js";
+import type { ISODateTime } from "../../domain/value-objects/iso-datetime.js";
+import type { PIIString } from "../../domain/value-objects/pii-string.js";
+import type { UUID } from "../../domain/value-objects/uuid.js";
+
+/**
+ * Input to `screen()` — either an Identity or a BusinessEntity projection.
+ * Names are PIIString to prevent accidental logging.
+ */
+export type ScreeningSubject =
+  | {
+      readonly kind: "IDENTITY";
+      readonly id: UUID;
+      readonly fullName: PIIString;
+      readonly dateOfBirth?: ISODateTime;
+      readonly country: string;
+    }
+  | {
+      readonly kind: "BUSINESS";
+      readonly id: UUID;
+      readonly legalName: PIIString;
+      readonly country: string;
+    };
+
+export type MatchResolution =
+  | { kind: "CONFIRMED_MATCH"; reviewer: string; notes?: string }
+  | { kind: "FALSE_POSITIVE"; reviewer: string; notes?: string };
+
+export interface RefreshReport {
+  readonly source: SanctionsList;
+  readonly fetchedAt: ISODateTime;
+  readonly entriesAdded: number;
+  readonly entriesRemoved: number;
+  readonly entriesUpdated: number;
+}
+
+/**
+ * SanctionsScreeningPort — outbound abstraction over OFAC/UN/EU feed adapters
+ * + enriched providers (SnapCompliance, OpenSanctions).
+ */
+export interface SanctionsScreeningPort {
+  /**
+   * Screen a subject against the configured lists. MUST return ALL matches
+   * above the configured confidence threshold (not just the best).
+   */
+  screen(subject: ScreeningSubject): Promise<readonly SanctionsMatch[]>;
+
+  /** Re-download and re-index a specific list source. */
+  refreshLists(source: SanctionsList): Promise<RefreshReport>;
+
+  /** Lookup a single match by id (for review UI). */
+  getMatch(id: UUID): Promise<SanctionsMatch | null>;
+
+  /** Mark a match as CONFIRMED_MATCH or FALSE_POSITIVE. */
+  resolveMatch(id: UUID, resolution: MatchResolution): Promise<SanctionsMatch>;
+}

--- a/packages/core/src/app/ports/verification-repository-port.ts
+++ b/packages/core/src/app/ports/verification-repository-port.ts
@@ -1,0 +1,43 @@
+import type { Identity } from "../../domain/entities/identity.js";
+import type { SanctionsMatch } from "../../domain/entities/sanctions-match.js";
+import type { VerificationSession } from "../../domain/entities/verification-session.js";
+import type { VerificationStatus } from "../../domain/services/state-machine.js";
+import type { ISODateTime } from "../../domain/value-objects/iso-datetime.js";
+import type { UUID } from "../../domain/value-objects/uuid.js";
+
+/**
+ * VerificationRepositoryPort — CRUD for Identity, VerificationSession,
+ * SanctionsMatch. Implementations use PostgreSQL with row-level encryption
+ * for PII columns.
+ *
+ * All methods MUST be idempotent for same-input re-plays (webhooks).
+ */
+
+export interface ListSessionsFilter {
+  readonly subjectId: UUID;
+  readonly status?: VerificationStatus;
+  readonly from?: ISODateTime;
+  readonly to?: ISODateTime;
+  readonly limit?: number;
+}
+
+export interface ListMatchesFilter {
+  readonly subjectId: UUID;
+  readonly status?: "PENDING" | "CONFIRMED_MATCH" | "FALSE_POSITIVE";
+  readonly limit?: number;
+}
+
+export interface VerificationRepositoryPort {
+  saveIdentity(identity: Identity): Promise<void>;
+  getIdentity(id: UUID): Promise<Identity | null>;
+
+  saveSession(session: VerificationSession): Promise<void>;
+  getSession(id: UUID): Promise<VerificationSession | null>;
+  /** Used by webhook handlers to find the session a provider is calling back about. */
+  getSessionByProviderRef(providerRef: string): Promise<VerificationSession | null>;
+
+  listSessionsBySubject(filter: ListSessionsFilter): Promise<readonly VerificationSession[]>;
+
+  saveMatch(match: SanctionsMatch): Promise<void>;
+  listMatchesBySubject(filter: ListMatchesFilter): Promise<readonly SanctionsMatch[]>;
+}


### PR DESCRIPTION
## Summary

Implements **Task 18** of the Fase 1 plan — 5 domain ports + contract tests + in-memory fakes.

- `IdentityVerificationPort`, `SanctionsScreeningPort`, `AuditLogPort`, `VerificationRepositoryPort`, `ProviderCredentialVault`.
- Contract suites (reusable for adapter packages) in `__contract__/`.
- In-memory fakes in `__fakes__/` for command tests (Tasks 19-21).

## Spec alignment

- spec §4 (domain model) + §5 (ports catalog).
- plan section `## Task 18 — Application ports: domain`.

## Security invariants baked in

- **PII-by-construction:** every identity-bearing input (fullName, legalName) is typed as `PIIString`; adapters cross the reveal boundary explicitly.
- **Disposable credentials:** `ProviderCredentialVault.loadCredentials()` returns a `DisposableCredentials` implementing `Symbol.dispose`. The contract test asserts `liveHandleCount() === 0` after the request scope closes.
- **Tamper detection:** the `AuditLogPort` contract test corrupts a stored hash and asserts `verify()` returns `ok:false` with the correct `brokenAt` and `reason`.

## Test plan

- [x] `pnpm test` green (100 tests total: +19 new domain-port contracts).
- [x] `pnpm typecheck` green.
- [x] `pnpm lint` green.
- [x] No raw PII flows through any fake — `PIIString` is the input type everywhere that receives a name.

Closes #22