### PR TITLE
feat(app): middleware chain (PII redactor, tracing, idempotency, metrics, auth)

### DIFF
--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -1,6 +1,7 @@
 // Public re-exports — consumers import from "@compliance-core/core/app"
 
 export * from "./errors.js";
+export * from "./middleware/index.js";
 export * from "./ports/index.js";
 
 // Commands

--- a/packages/core/src/app/middleware/auth.ts
+++ b/packages/core/src/app/middleware/auth.ts
@@ -1,0 +1,58 @@
+import { ApplicationError } from "../errors.js";
+import type { Middleware, Principal, RequestContext } from "./types.js";
+
+/**
+ * Auth middleware — verifies the caller is authenticated + authorized and
+ * attaches the verified `Principal` to the RequestContext.
+ *
+ * The middleware is transport-agnostic: callers supply a `verify` function
+ * that translates whatever credential the transport produced (JWT, mTLS
+ * peer cert, service token) into a `Principal`. If verification fails or
+ * the caller lacks a required scope, throws `Unauthorized`.
+ */
+
+export class Unauthorized extends ApplicationError {
+  constructor(msg = "Unauthorized") {
+    super(msg);
+  }
+}
+
+export class Forbidden extends ApplicationError {
+  constructor(msg = "Forbidden") {
+    super(msg);
+  }
+}
+
+export interface AuthCredential {
+  readonly kind: "jwt" | "mtls";
+  readonly raw: string;
+}
+
+export interface AuthMiddlewareDeps<I> {
+  readonly verify: (credential: AuthCredential) => Promise<Principal | null>;
+  readonly extractCredential: (input: I, ctx: RequestContext) => AuthCredential | undefined;
+  readonly requiredScopes?: readonly string[];
+}
+
+export function auth<I, O>(deps: AuthMiddlewareDeps<I>): Middleware<I, O> {
+  return (next) => async (input, ctx) => {
+    const credential = deps.extractCredential(input, ctx);
+    if (!credential) throw new Unauthorized("missing credential");
+    const principal = await deps.verify(credential);
+    if (!principal) throw new Unauthorized("invalid credential");
+
+    if (deps.requiredScopes && deps.requiredScopes.length > 0) {
+      const missing = deps.requiredScopes.filter((s) => !principal.scopes.includes(s));
+      if (missing.length > 0) {
+        throw new Forbidden(`missing scopes: ${missing.join(",")}`);
+      }
+    }
+
+    const verifiedCtx: RequestContext = {
+      correlationId: ctx.correlationId,
+      commandName: ctx.commandName,
+      principal,
+    };
+    return next(input, verifiedCtx);
+  };
+}

--- a/packages/core/src/app/middleware/idempotency.ts
+++ b/packages/core/src/app/middleware/idempotency.ts
@@ -1,0 +1,24 @@
+import type { IdempotencyPort } from "../ports/idempotency-port.js";
+import type { Middleware } from "./types.js";
+
+/**
+ * Idempotency middleware. Keys by `(tenantId, commandName, idempotencyKey)`.
+ * Callers must supply an `idempotencyKey` field on the input (or request
+ * scope) for this middleware to activate — when absent, the middleware is a
+ * pass-through. TTL is configurable per-chain.
+ */
+
+export interface IdempotencyMiddlewareDeps {
+  readonly idempotency: IdempotencyPort;
+  readonly ttlMs: number;
+  readonly extractKey: (input: unknown) => string | undefined;
+}
+
+export function idempotency<I, O>(deps: IdempotencyMiddlewareDeps): Middleware<I, O> {
+  return (next) => async (input, ctx) => {
+    const idemKey = deps.extractKey(input);
+    if (!idemKey) return next(input, ctx);
+    const fullKey = `${ctx.principal.tenantId}:${ctx.commandName}:${idemKey}`;
+    return deps.idempotency.run(fullKey, deps.ttlMs, () => next(input, ctx));
+  };
+}

--- a/packages/core/src/app/middleware/index.ts
+++ b/packages/core/src/app/middleware/index.ts
@@ -1,0 +1,18 @@
+export {
+  auth,
+  Forbidden,
+  Unauthorized,
+  type AuthMiddlewareDeps,
+  type AuthCredential,
+} from "./auth.js";
+export { idempotency, type IdempotencyMiddlewareDeps } from "./idempotency.js";
+export { metrics, type MetricsMiddlewareDeps } from "./metrics.js";
+export { piiRedactor, redact, type PIIRedactorDeps, type RedactOptions } from "./pii-redactor.js";
+export { tracing, type TracingMiddlewareDeps } from "./tracing.js";
+export {
+  compose,
+  type Handler,
+  type Middleware,
+  type Principal,
+  type RequestContext,
+} from "./types.js";

--- a/packages/core/src/app/middleware/metrics.ts
+++ b/packages/core/src/app/middleware/metrics.ts
@@ -1,0 +1,40 @@
+import type { ClockPort } from "../ports/clock-port.js";
+import type { MetricsPort } from "../ports/metrics-port.js";
+import type { Middleware } from "./types.js";
+
+/**
+ * Metrics middleware — counts command invocations and measures latency.
+ *
+ * Emits:
+ *  - counter `command_total{name,tenant,result}` (result in {ok, error}).
+ *  - histogram `command_duration_seconds{name,tenant}`.
+ *
+ * Labels are intentionally low-cardinality (tenantId cardinality grows
+ * with customer count, but stays bounded).
+ */
+
+export interface MetricsMiddlewareDeps {
+  readonly metrics: MetricsPort;
+  readonly clock: ClockPort;
+}
+
+export function metrics<I, O>(deps: MetricsMiddlewareDeps): Middleware<I, O> {
+  return (next) => async (input, ctx) => {
+    const t0 = deps.clock.now().getTime();
+    const labels = { name: ctx.commandName, tenant: ctx.principal.tenantId };
+    try {
+      const out = await next(input, ctx);
+      deps.metrics.counter("command_total", { ...labels, result: "ok" }).inc();
+      deps.metrics
+        .histogram("command_duration_seconds", labels)
+        .observe((deps.clock.now().getTime() - t0) / 1000);
+      return out;
+    } catch (err) {
+      deps.metrics.counter("command_total", { ...labels, result: "error" }).inc();
+      deps.metrics
+        .histogram("command_duration_seconds", labels)
+        .observe((deps.clock.now().getTime() - t0) / 1000);
+      throw err;
+    }
+  };
+}

--- a/packages/core/src/app/middleware/middleware.test.ts
+++ b/packages/core/src/app/middleware/middleware.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PIIString } from "../../domain/value-objects/pii-string.js";
+import { FakeClock } from "../ports/__fakes__/fake-clock.js";
+import { FakeIdempotency } from "../ports/__fakes__/fake-idempotency.js";
+import { FakeMetrics } from "../ports/__fakes__/fake-metrics.js";
+import { FakeTracing } from "../ports/__fakes__/fake-tracing.js";
+
+import { Forbidden, Unauthorized, auth } from "./auth.js";
+import { idempotency } from "./idempotency.js";
+import { metrics } from "./metrics.js";
+import { piiRedactor, redact } from "./pii-redactor.js";
+import { tracing } from "./tracing.js";
+import { type Handler, type RequestContext, compose } from "./types.js";
+
+const CTX: RequestContext = {
+  correlationId: "corr-1",
+  commandName: "TestCommand",
+  principal: {
+    tenantId: "tenant-a",
+    subjectKind: "USER",
+    subjectId: "u-1",
+    scopes: ["cmd:execute"],
+  },
+};
+
+describe("redact() — PII fixture (spec-required)", () => {
+  it("redacts PIIString, forbidden keys, and deep-walks objects/arrays", () => {
+    const input = {
+      subject: {
+        fullName: PIIString.from("Ada Lovelace"),
+        taxId: "1-1234-5678", // cédula CR
+        documentNumber: "P12345678", // passport
+        dateOfBirth: "1815-12-10",
+      },
+      items: [{ fullName: PIIString.from("Grace Hopper") }, { note: "neutral text" }],
+      correlationId: "corr-42",
+    };
+    const out = redact(input);
+    const serialized = JSON.stringify(out);
+
+    // Spec requirement: cédula and passport MUST NOT appear verbatim.
+    expect(serialized).not.toContain("1-1234-5678");
+    expect(serialized).not.toContain("P12345678");
+    expect(serialized).not.toContain("Ada Lovelace");
+    expect(serialized).not.toContain("Grace Hopper");
+
+    // Non-PII fields survive.
+    expect(serialized).toContain("corr-42");
+    expect(serialized).toContain("neutral text");
+  });
+});
+
+describe("piiRedactor middleware", () => {
+  it("emits redacted input/output via onLog without mutating the real input", async () => {
+    const logs: unknown[] = [];
+    const handler: Handler<{ fullName: PIIString; sessionId: string }, { ok: true }> = async (
+      input,
+    ) => {
+      // Handler sees the raw PIIString (can unsafeReveal internally).
+      expect(input.fullName).toBeInstanceOf(PIIString);
+      expect(input.fullName.unsafeReveal()).toBe("Ada Lovelace");
+      return { ok: true };
+    };
+    const wrapped = piiRedactor<{ fullName: PIIString; sessionId: string }, { ok: true }>({
+      onLog: (e) => logs.push(e),
+    })(handler);
+    await wrapped({ fullName: PIIString.from("Ada Lovelace"), sessionId: "sess-1" }, CTX);
+    const serialized = JSON.stringify(logs);
+    expect(serialized).not.toContain("Ada Lovelace");
+    expect(serialized).toContain("[REDACTED]");
+    expect(serialized).toContain("sess-1");
+  });
+
+  it("captures errors with redacted fields", async () => {
+    const logs: unknown[] = [];
+    const handler: Handler<unknown, unknown> = async () => {
+      throw new Error("boom");
+    };
+    const wrapped = piiRedactor({ onLog: (e) => logs.push(e) })(handler);
+    await expect(wrapped({}, CTX)).rejects.toThrow("boom");
+    const errorLog = logs.find((l) => (l as { phase: string }).phase === "error");
+    expect(errorLog).toBeDefined();
+  });
+});
+
+describe("tracing middleware", () => {
+  it("wraps handler in a named span with correlation + tenant attrs", async () => {
+    const tracer = new FakeTracing();
+    const handler: Handler<{ x: number }, { y: number }> = async (i) => ({ y: i.x * 2 });
+    const wrapped = tracing<{ x: number }, { y: number }>({ tracing: tracer })(handler);
+    const out = await wrapped({ x: 3 }, CTX);
+    expect(out.y).toBe(6);
+    expect(tracer.spans).toHaveLength(1);
+    expect(tracer.spans[0]?.name).toBe("command.TestCommand");
+    expect(tracer.spans[0]?.attrs).toMatchObject({
+      correlation_id: "corr-1",
+      tenant_id: "tenant-a",
+    });
+  });
+
+  it("records exceptions + re-throws", async () => {
+    const tracer = new FakeTracing();
+    const handler: Handler<unknown, unknown> = async () => {
+      throw new Error("bad");
+    };
+    const wrapped = tracing({ tracing: tracer })(handler);
+    await expect(wrapped({}, CTX)).rejects.toThrow("bad");
+    const span = tracer.spans[0];
+    expect(span?.events.some((e) => e.kind === "exception")).toBe(true);
+    expect(span?.events.some((e) => e.kind === "status")).toBe(true);
+  });
+});
+
+describe("idempotency middleware", () => {
+  it("keys by (tenant, command, idempotencyKey) and caches", async () => {
+    const port = new FakeIdempotency();
+    const seen: number[] = [];
+    let counter = 0;
+    const handler: Handler<{ idempotencyKey?: string }, number> = async () => {
+      counter += 1;
+      seen.push(counter);
+      return counter;
+    };
+    const wrapped = idempotency<{ idempotencyKey?: string }, number>({
+      idempotency: port,
+      ttlMs: 60_000,
+      extractKey: (i) => i.idempotencyKey,
+    })(handler);
+    const a = await wrapped({ idempotencyKey: "K-1" }, CTX);
+    const b = await wrapped({ idempotencyKey: "K-1" }, CTX);
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(seen).toEqual([1]);
+  });
+
+  it("passes through when no idempotencyKey present", async () => {
+    const port = new FakeIdempotency();
+    let counter = 0;
+    const handler: Handler<{ idempotencyKey?: string }, number> = async () => {
+      counter += 1;
+      return counter;
+    };
+    const wrapped = idempotency<{ idempotencyKey?: string }, number>({
+      idempotency: port,
+      ttlMs: 60_000,
+      extractKey: (i) => i.idempotencyKey,
+    })(handler);
+    await wrapped({}, CTX);
+    await wrapped({}, CTX);
+    expect(counter).toBe(2);
+  });
+});
+
+describe("metrics middleware", () => {
+  it("records counter + histogram on success and on failure", async () => {
+    const m = new FakeMetrics();
+    const clock = new FakeClock("2026-04-20T12:00:00.000Z");
+    const okHandler: Handler<void, string> = async () => {
+      clock.advance(50);
+      return "ok";
+    };
+    const errHandler: Handler<void, string> = async () => {
+      clock.advance(20);
+      throw new Error("fail");
+    };
+    const okWrapped = metrics<void, string>({ metrics: m, clock })(okHandler);
+    const errWrapped = metrics<void, string>({ metrics: m, clock })(errHandler);
+
+    await okWrapped(undefined, CTX);
+    await expect(errWrapped(undefined, CTX)).rejects.toThrow();
+
+    const okKey = "command_total{name=TestCommand,result=ok,tenant=tenant-a}";
+    const errKey = "command_total{name=TestCommand,result=error,tenant=tenant-a}";
+    expect(m.recorded.counters.get(okKey)).toBe(1);
+    expect(m.recorded.counters.get(errKey)).toBe(1);
+  });
+});
+
+describe("auth middleware", () => {
+  it("attaches verified principal to context", async () => {
+    let seenPrincipal: RequestContext["principal"] | null = null;
+    const handler: Handler<{ token: string }, boolean> = async (_i, ctx) => {
+      seenPrincipal = ctx.principal;
+      return true;
+    };
+    const wrapped = auth<{ token: string }, boolean>({
+      extractCredential: (i) => ({ kind: "jwt", raw: i.token }),
+      verify: async (c) =>
+        c.raw === "good"
+          ? {
+              tenantId: "t-auth",
+              subjectKind: "USER",
+              subjectId: "u-auth",
+              scopes: ["cmd:execute"],
+            }
+          : null,
+    })(handler);
+    await wrapped({ token: "good" }, CTX);
+    expect(seenPrincipal).toMatchObject({ tenantId: "t-auth", subjectId: "u-auth" });
+  });
+
+  it("throws Unauthorized on bad/missing credential", async () => {
+    const handler: Handler<{ token?: string }, boolean> = async () => true;
+    const wrapped = auth<{ token?: string }, boolean>({
+      extractCredential: (i) => (i.token ? { kind: "jwt", raw: i.token } : undefined),
+      verify: async () => null,
+    })(handler);
+    await expect(wrapped({}, CTX)).rejects.toBeInstanceOf(Unauthorized);
+    await expect(wrapped({ token: "x" }, CTX)).rejects.toBeInstanceOf(Unauthorized);
+  });
+
+  it("throws Forbidden when scopes missing", async () => {
+    const handler: Handler<{ token: string }, boolean> = async () => true;
+    const wrapped = auth<{ token: string }, boolean>({
+      extractCredential: (i) => ({ kind: "jwt", raw: i.token }),
+      verify: async () => ({
+        tenantId: "t-x",
+        subjectKind: "USER",
+        subjectId: "u-x",
+        scopes: [],
+      }),
+      requiredScopes: ["cmd:execute"],
+    })(handler);
+    await expect(wrapped({ token: "good" }, CTX)).rejects.toBeInstanceOf(Forbidden);
+  });
+});
+
+describe("compose", () => {
+  it("runs middlewares outside-in and returns handler value", async () => {
+    const order: string[] = [];
+    const log = (name: string) => ({
+      enter: () => order.push(`enter:${name}`),
+      exit: () => order.push(`exit:${name}`),
+    });
+    const mw =
+      (name: string) =>
+      () =>
+      (next: Handler<number, number>) =>
+      async (i: number, c: RequestContext) => {
+        log(name).enter();
+        const o = await next(i, c);
+        log(name).exit();
+        return o;
+      };
+    const handler: Handler<number, number> = async (i) => {
+      order.push("handler");
+      return i + 1;
+    };
+    const outer = mw("A")();
+    const middle = mw("B")();
+    const chain = compose<number, number>(outer, middle);
+    const wrapped = chain(handler);
+    const out = await wrapped(10, CTX);
+    expect(out).toBe(11);
+    expect(order).toEqual(["enter:A", "enter:B", "handler", "exit:B", "exit:A"]);
+  });
+});
+
+describe("integration: full chain end-to-end", () => {
+  it("composed chain still redacts PII from logs + records metrics + spans", async () => {
+    const tracer = new FakeTracing();
+    const mmetrics = new FakeMetrics();
+    const idemPort = new FakeIdempotency();
+    const clock = new FakeClock("2026-04-20T12:00:00.000Z");
+    const logs: unknown[] = [];
+
+    interface I {
+      readonly idempotencyKey?: string;
+      readonly fullName: PIIString;
+      readonly token: string;
+    }
+    interface O {
+      readonly ok: true;
+    }
+
+    const onLog = vi.fn((e: unknown) => {
+      logs.push(e);
+    });
+
+    const chain = compose<I, O>(
+      auth<I, O>({
+        extractCredential: (i) => ({ kind: "jwt", raw: i.token }),
+        verify: async (c) =>
+          c.raw === "good"
+            ? { tenantId: "tenant-a", subjectKind: "USER", subjectId: "u-1", scopes: [] }
+            : null,
+      }),
+      piiRedactor<I, O>({ onLog }),
+      tracing<I, O>({ tracing: tracer }),
+      idempotency<I, O>({
+        idempotency: idemPort,
+        ttlMs: 60_000,
+        extractKey: (i) => i.idempotencyKey,
+      }),
+      metrics<I, O>({ metrics: mmetrics, clock }),
+    );
+
+    const handler: Handler<I, O> = async () => ({ ok: true });
+    const wrapped = chain(handler);
+
+    await wrapped(
+      { fullName: PIIString.from("Ada Lovelace"), token: "good", idempotencyKey: "K1" },
+      CTX,
+    );
+
+    // No raw PII in any captured log line.
+    const serializedLogs = JSON.stringify(logs);
+    expect(serializedLogs).not.toContain("Ada Lovelace");
+
+    // Tracing captured.
+    expect(tracer.spans).toHaveLength(1);
+    // Metrics recorded.
+    expect(
+      mmetrics.recorded.counters.get("command_total{name=TestCommand,result=ok,tenant=tenant-a}"),
+    ).toBe(1);
+
+    // Replay with same idempotency key runs handler only once.
+    await wrapped(
+      { fullName: PIIString.from("Ada Lovelace"), token: "good", idempotencyKey: "K1" },
+      CTX,
+    );
+    // Counter stays at 1 because handler was skipped (cached result short-circuits metrics too since
+    // metrics runs INSIDE idempotency's inner scope only on first execution).
+    expect(
+      mmetrics.recorded.counters.get("command_total{name=TestCommand,result=ok,tenant=tenant-a}"),
+    ).toBe(1);
+  });
+});

--- a/packages/core/src/app/middleware/pii-redactor.ts
+++ b/packages/core/src/app/middleware/pii-redactor.ts
@@ -1,0 +1,106 @@
+import { PIIString } from "../../domain/value-objects/pii-string.js";
+import type { Middleware } from "./types.js";
+
+/**
+ * Returns a deep-cloned copy of `value` in which every `PIIString` has been
+ * replaced with the literal `"[REDACTED]"`, and every field whose key is in
+ * `forbiddenKeys` (recursively) is also redacted.
+ *
+ * Unlike `JSON.stringify`, this works for passing values to loggers /
+ * tracers / metrics that DO NOT walk through JSON serialization (pino's
+ * fast-path accepts pre-transformed objects).
+ *
+ * NEVER mutates the input; commands receive the raw value back unchanged.
+ */
+
+const DEFAULT_FORBIDDEN = new Set([
+  "taxId",
+  "fullName",
+  "documentNumber",
+  "dateOfBirth",
+  "evidenceBlob",
+  "narrative",
+  "contactHint",
+]);
+
+const REDACTED = "[REDACTED]" as const;
+
+export interface RedactOptions {
+  readonly forbiddenKeys?: ReadonlySet<string>;
+}
+
+export function redact(value: unknown, options: RedactOptions = {}): unknown {
+  const keys = options.forbiddenKeys ?? DEFAULT_FORBIDDEN;
+  return walk(value, keys);
+}
+
+function walk(value: unknown, keys: ReadonlySet<string>): unknown {
+  if (value === null || value === undefined) return value;
+  if (value instanceof PIIString) return REDACTED;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map((v) => walk(v, keys));
+  if (typeof value === "object") {
+    const src = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(src)) {
+      out[k] = keys.has(k) ? REDACTED : walk(v, keys);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * PII-redactor middleware — builds redacted snapshots of input / output and
+ * exposes them via the `onLog` callback. Commands still receive / return
+ * the raw values.
+ */
+export interface PIIRedactorDeps {
+  readonly onLog?: (event: {
+    phase: "enter" | "exit" | "error";
+    commandName: string;
+    correlationId: string;
+    redactedInput?: unknown;
+    redactedOutput?: unknown;
+    redactedError?: unknown;
+  }) => void;
+  readonly options?: RedactOptions;
+}
+
+export function piiRedactor<I, O>(deps: PIIRedactorDeps = {}): Middleware<I, O> {
+  return (next) => async (input, ctx) => {
+    const redactedInput = redact(input, deps.options);
+    deps.onLog?.({
+      phase: "enter",
+      commandName: ctx.commandName,
+      correlationId: ctx.correlationId,
+      redactedInput,
+    });
+    try {
+      const output = await next(input, ctx);
+      deps.onLog?.({
+        phase: "exit",
+        commandName: ctx.commandName,
+        correlationId: ctx.correlationId,
+        redactedOutput: redact(output, deps.options),
+      });
+      return output;
+    } catch (error) {
+      deps.onLog?.({
+        phase: "error",
+        commandName: ctx.commandName,
+        correlationId: ctx.correlationId,
+        redactedError: redact(
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : { message: String(error) },
+          deps.options,
+        ),
+      });
+      throw error;
+    }
+  };
+}

--- a/packages/core/src/app/middleware/tracing.ts
+++ b/packages/core/src/app/middleware/tracing.ts
@@ -1,0 +1,38 @@
+import type { TracingPort } from "../ports/tracing-port.js";
+import { redact } from "./pii-redactor.js";
+import type { Middleware } from "./types.js";
+
+/**
+ * Tracing middleware. Wraps the handler in `startSpan` with
+ * `correlation_id`, `tenant_id`, `command_name` attributes. On failure,
+ * records the exception with a redacted `message` (errors MAY embed PII if
+ * an exception bubbles up from domain; pre-redact as a safety net).
+ */
+export interface TracingMiddlewareDeps {
+  readonly tracing: TracingPort;
+}
+
+export function tracing<I, O>(deps: TracingMiddlewareDeps): Middleware<I, O> {
+  return (next) => (input, ctx) =>
+    deps.tracing.startSpan(
+      `command.${ctx.commandName}`,
+      async (span) => {
+        try {
+          return await next(input, ctx);
+        } catch (error) {
+          const redactedMessage =
+            error instanceof Error
+              ? (redact({ message: error.message }) as { message: string }).message
+              : "error";
+          span.recordException({ name: "CommandError", message: redactedMessage });
+          span.setStatus({ code: "ERROR", message: redactedMessage });
+          throw error;
+        }
+      },
+      {
+        correlation_id: ctx.correlationId,
+        tenant_id: ctx.principal.tenantId,
+        command_name: ctx.commandName,
+      },
+    );
+}

--- a/packages/core/src/app/middleware/types.ts
+++ b/packages/core/src/app/middleware/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Generic middleware types for the compliance-core application layer.
+ *
+ * A `Handler<I, O>` is a single function that executes a command / query.
+ * A `Middleware<I, O>` wraps a handler to add cross-cutting concerns
+ * (PII redaction, tracing, idempotency, metrics, auth).
+ *
+ * Middlewares compose via `compose(...)` — first argument is the outermost
+ * (runs first on the way in, last on the way out).
+ */
+
+export interface Principal {
+  readonly tenantId: string;
+  readonly subjectKind: "USER" | "SERVICE" | "SYSTEM";
+  readonly subjectId: string;
+  readonly scopes: readonly string[];
+}
+
+export interface RequestContext {
+  readonly correlationId: string;
+  readonly principal: Principal;
+  readonly commandName: string;
+}
+
+export type Handler<I, O> = (input: I, ctx: RequestContext) => Promise<O>;
+
+export type Middleware<I, O> = (next: Handler<I, O>) => Handler<I, O>;
+
+/**
+ * Compose middlewares left-to-right: the first element of the array wraps
+ * the handler last (i.e. it runs outermost). This matches Koa/Express
+ * conventions.
+ */
+export function compose<I, O>(...middlewares: ReadonlyArray<Middleware<I, O>>): Middleware<I, O> {
+  return (handler) => {
+    let wrapped = handler;
+    for (let i = middlewares.length - 1; i >= 0; i -= 1) {
+      const mw = middlewares[i];
+      if (mw === undefined) continue;
+      wrapped = mw(wrapped);
+    }
+    return wrapped;
+  };
+}


### PR DESCRIPTION
## Summary

Implements **Task 21** (priority/p0). Closes the Fase 1 application layer by shipping the cross-cutting middleware chain every command / query is expected to run through.

Files in `packages/core/src/app/middleware/`:
- `types.ts`: generic `Middleware<I,O>`, `Handler<I,O>`, `RequestContext`, `Principal`, `compose()`.
- `pii-redactor.ts`: pure `redact()` + `piiRedactor` middleware. Deep-walks values; replaces `PIIString` + forbidden-key values with `[REDACTED]`.
- `tracing.ts`: `startSpan` wrapper; records exceptions with a redacted message.
- `idempotency.ts`: keyed by `(tenantId, commandName, idempotencyKey)`.
- `metrics.ts`: `command_total{name,tenant,result}` counter + `command_duration_seconds{name,tenant}` histogram.
- `auth.ts`: transport-agnostic; throws `Unauthorized` / `Forbidden`.

## Spec alignment

- spec §3 (middleware stack) + §12 (security model).
- plan section `## Task 21`.

## Invariants exercised by tests

1. **PII fixture (plan mandate):** logs for a command whose input carries `1-1234-5678` (cédula CR) + `P12345678` (passport) + two `PIIString` fullName values contain NEITHER value verbatim. `[REDACTED]` appears instead, and non-PII correlation IDs survive.
2. **Handler still sees raw PII:** the PII-redactor test explicitly calls `input.fullName.unsafeReveal()` inside the handler to prove the middleware redacts for observability without mutating the real input.
3. **End-to-end chain:** an integration test composes `auth → piiRedactor → tracing → idempotency → metrics` and asserts all five concerns fire together for a single call. Replay with the same idempotency key does NOT double-count the metrics counter.
4. **Error paths:** bad JWT → `Unauthorized`; missing scope → `Forbidden`; handler throw → tracing records exception + status ERROR; metrics counts `result=error`.

## Test plan

- [x] `pnpm test` green — 138 tests (+13 new middleware tests including PII fixture + full-chain integration).
- [x] `pnpm typecheck` green.
- [x] `pnpm lint` green (biome).
- [x] No PII string leaks from any of the captured observability outputs.

Closes #25